### PR TITLE
Fix shared library output generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries (sndfile_static PUBLIC ${EXTERNAL_XIPH_LIBS} m)
 
 set_target_properties (sndfile sndfile_static
 			PROPERTIES
+			SOVERSION ${PROJECT_VERSION_MAJOR}
 			VERSION ${PROJECT_VERSION}
 			POSITION_INDEPENDENT_CODE TRUE)
 target_include_directories (sndfile PUBLIC


### PR DESCRIPTION
Without setting `SONAME` output was:

```
libsndfile.so
libsndfile.so.1.0.28
```

After fix:

```
libsndfile.so
libsndfile.so.1
libsndfile.so.1.0.28
```

CMake documentation doesn't explain it clearly. That's the rules:
- `VERSION` must be set to full version (1.0.28)
- `SOVERSION` must be the major version number (1), NOT full version
- Full version major number (1.x.x) must be equal to `SOVERSION`
